### PR TITLE
Bugfix/incorrect handling of reconnect

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -12,6 +12,12 @@ Release Notes
 .. release:: Upcoming
 
     .. change:: fixed
+        :tags: event
+
+        Events published while the event hub is reconnecting are now queued
+        and published once the event hub has reconnected.
+
+    .. change:: fixed
         :tags: session
 
         Server URL can contain a trailing slash "/" without causing an error.

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -224,6 +224,8 @@ def test_disconnect(event_hub):
     assert len(event_hub._subscribers) == 0
 
     assert event_hub._intentional_disconnect is True
+    assert event_hub._connection_initialised is False
+
     assert event_hub.connected is False
 
 
@@ -232,12 +234,14 @@ def test_disconnect_without_unsubscribing(event_hub):
     event_hub.disconnect(unsubscribe=False)
     assert len(event_hub._subscribers) > 0
     assert event_hub.connected is False
+    assert event_hub._connection_initialised is False
 
 
 def test_disconnect_with_reconnect(event_hub):
     '''Disconnect with the intention of reconnecting.'''
     event_hub.disconnect(reconnect=True)
-    assert event_hub._intentional_disconnect is False
+    assert event_hub._connection_initialised is True
+
     assert event_hub.connected is False
 
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -222,6 +222,8 @@ def test_disconnect(event_hub):
     '''Disconnect and unsubscribe all subscribers.'''
     event_hub.disconnect()
     assert len(event_hub._subscribers) == 0
+
+    assert event_hub._intentional_disconnect is True
     assert event_hub.connected is False
 
 
@@ -229,6 +231,13 @@ def test_disconnect_without_unsubscribing(event_hub):
     '''Disconnect without unsubscribing all subscribers.'''
     event_hub.disconnect(unsubscribe=False)
     assert len(event_hub._subscribers) > 0
+    assert event_hub.connected is False
+
+
+def test_disconnect_with_reconnect(event_hub):
+    '''Disconnect with the intention of reconnecting.'''
+    event_hub.disconnect(reconnect=True)
+    assert event_hub._intentional_disconnect is False
     assert event_hub.connected is False
 
 


### PR DESCRIPTION
- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [x] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
When a reconnect operation happens due to a server / connection error we do not handle the published events during this period correctly ( They should be queued up and published once the connection is reestablished. ). ie we relied on the _intentional_disconnect flag to determine if we should queue the published events. instead only rely on _intentional_disconnect to determine the behavior.

## Test
I found this easier to replicate in python 3.7 ( perhaps in relation to this issue https://bugs.python.org/issue32533 ) that appears to affect our ftrack-connect-package builds.


