### PR TITLE
feature: add support for strict api calls in python client

### DIFF
--- a/source/ftrack_api/accessor/server.py
+++ b/source/ftrack_api/accessor/server.py
@@ -46,7 +46,7 @@ class ServerFile(String):
         position = self.tell()
         self.seek(0)
 
-        response = requests.get(
+        response = self._session._request.get(
             '{0}/component/get'.format(self._session.server_url),
             params={
                 'id': self.resource_identifier,
@@ -107,7 +107,7 @@ class ServerFile(String):
         self.seek(0)
 
         # Put the file based on the metadata.
-        response = requests.put(
+        response = self._session._request.put(
             metadata['url'],
             data=self.wrapped_file,
             headers=metadata['headers']
@@ -165,7 +165,7 @@ class _ServerAccessor(Accessor):
 
     def remove(self, resourceIdentifier):
         '''Remove *resourceIdentifier*.'''
-        response = requests.get(
+        response = self._session._request.get(
             '{0}/component/remove'.format(self._session.server_url),
             params={
                 'id': resourceIdentifier,

--- a/source/ftrack_api/accessor/server.py
+++ b/source/ftrack_api/accessor/server.py
@@ -46,7 +46,7 @@ class ServerFile(String):
         position = self.tell()
         self.seek(0)
 
-        response = self._session._request.get(
+        response = requests.get(
             '{0}/component/get'.format(self._session.server_url),
             params={
                 'id': self.resource_identifier,
@@ -107,7 +107,7 @@ class ServerFile(String):
         self.seek(0)
 
         # Put the file based on the metadata.
-        response = self._session._request.put(
+        response = requests.put(
             metadata['url'],
             data=self.wrapped_file,
             headers=metadata['headers']
@@ -165,7 +165,7 @@ class _ServerAccessor(Accessor):
 
     def remove(self, resourceIdentifier):
         '''Remove *resourceIdentifier*.'''
-        response = self._session._request.get(
+        response = requests.get(
             '{0}/component/remove'.format(self._session.server_url),
             params={
                 'id': resourceIdentifier,

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -883,7 +883,7 @@ class EventHub(object):
             }
             response = requests.get(
                 socket_io_url,
-                headers=req_headers.update(self._headers) if self._headers else req_headers,
+                headers=req_headers,#.update(self._headers) if self._headers else req_headers,
                 cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -56,6 +56,12 @@ class EventHub(object):
 
         *api_user* is the user to authenticate as and *api_key* is the API key
         to authenticate with.
+        
+        *cookies* should be an optional mapping (dict) of key-value pairs specifying
+        custom cookies that we need to pass in alongside the requests to the server.
+
+        *headers* should be an optional mapping (dict) of key-value pairs specifying
+        custom headers that we need to pass in alongside the requests to the server.
 
         '''
         super(EventHub, self).__init__()

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -881,9 +881,11 @@ class EventHub(object):
                 'ftrack-user': self._api_user,
                 'ftrack-api-key': self._api_key
             }
+            if self._headers:
+                req_headers.update(self._headers)
             response = requests.get(
                 socket_io_url,
-                headers=req_headers.update(self._headers) if self._headers else req_headers,
+                headers=req_headers,
                 cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -121,21 +121,25 @@ class EventHub(object):
             url_parse_result.port
         )
         
-        self._cookies = None
         if cookies is not None:
             if not isinstance(cookies, collections_abc.Mapping):
                 raise TypeError('The cookies argument is required to be a mapping.')
             self._cookies = ';'.join(['{0}={1}'.format(x, cookies[x]) for x in cookies.keys()])
+        else:
+            self._cookies = ''
 
-        self._headers = None
         if headers is not None:
             if not isinstance(headers, collections_abc.Mapping):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._headers = headers
+        else:
+            self._headers = {}
         
         if not isinstance(ftrack_strict_api, bool):
             raise TypeError('The ftrack_strict_api argument is required to be a boolean.')
-        self._headers.update({'ftrack-strict-api': 'true' if ftrack_strict_api else 'false'})
+        self._headers.update(
+            {'ftrack-strict-api': 'true' if ftrack_strict_api is True else 'false'}
+        )
 
     def get_server_url(self):
         '''Return URL to server.'''

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -866,7 +866,7 @@ class EventHub(object):
             }
             if self._headers:
                 req_headers.update(self._headers)
-            response = requests.get(
+            response = self._session._request.get(
                 socket_io_url,
                 headers=req_headers,
                 cookies=self._cookies,

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -124,10 +124,8 @@ class EventHub(object):
         if cookies is not None:
             if not isinstance(cookies, collections_abc.Mapping):
                 raise TypeError('The cookies argument is required to be a mapping.')
-            self._cookies_str = ';'.join(['{0}={1}'.format(x, cookies[x]) for x in cookies.keys()])
             self._cookies = cookies
         else:
-            self._cookies_str = ''
             self._cookies = {}
 
         if headers is not None:
@@ -229,7 +227,8 @@ class EventHub(object):
             # https://docs.python.org/2/library/socket.html#socket.socket.setblocking
             self._connection = websocket.create_connection(
                 url, timeout=60, sslopt={"ssl_version": available_ssl_protocol},
-                enable_multithread= True, header=self._headers, cookie=self._cookies_str
+                enable_multithread= True, header=self._headers,
+                cookie=';'.join(['{0}={1}'.format(x, self._cookies[x]) for x in self._cookies.keys()])
             )
 
         except Exception as error:

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -866,7 +866,7 @@ class EventHub(object):
             }
             if self._headers:
                 req_headers.update(self._headers)
-            response = self._session._request.get(
+            response = requests.get(
                 socket_io_url,
                 headers=req_headers,
                 cookies=self._cookies,

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -51,7 +51,7 @@ ServerDetails = collections.namedtuple('ServerDetails', [
 class EventHub(object):
     '''Manage routing of events.'''
 
-    def __init__(self, server_url, api_user, api_key, headers=None, cookies=None, ftrack_strict_api=False):
+    def __init__(self, server_url, api_user, api_key, headers=None, cookies=None):
         '''Initialise hub, connecting to ftrack *server_url*.
 
         *api_user* is the user to authenticate as and *api_key* is the API key
@@ -121,25 +121,8 @@ class EventHub(object):
             url_parse_result.port
         )
         
-        if cookies is not None:
-            if not isinstance(cookies, collections_abc.Mapping):
-                raise TypeError('The cookies argument is required to be a mapping.')
-            self._cookies = cookies
-        else:
-            self._cookies = {}
-
-        if headers is not None:
-            if not isinstance(headers, collections_abc.Mapping):
-                raise TypeError('The headers argument is required to be a mapping.')
-            self._headers = headers
-        else:
-            self._headers = {}
-        
-        if not isinstance(ftrack_strict_api, bool):
-            raise TypeError('The ftrack_strict_api argument is required to be a boolean.')
-        self._headers.update(
-            {'ftrack-strict-api': 'true' if ftrack_strict_api is True else 'false'}
-        )
+        self._cookies = cookies or {}
+        self._headers = headers or {}
 
     def get_server_url(self):
         '''Return URL to server.'''

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -883,7 +883,7 @@ class EventHub(object):
             }
             response = requests.get(
                 socket_io_url,
-                headers=req_headers,#.update(self._headers) if self._headers else req_headers,
+                headers=req_headers.update(self._headers) if self._headers else req_headers,
                 cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -882,7 +882,7 @@ class EventHub(object):
                 headers={
                     'ftrack-user': self._api_user,
                     'ftrack-api-key': self._api_key
-                } | self._headers,
+                }.update(self._headers),
                 cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -124,9 +124,11 @@ class EventHub(object):
         if cookies is not None:
             if not isinstance(cookies, collections_abc.Mapping):
                 raise TypeError('The cookies argument is required to be a mapping.')
-            self._cookies = ';'.join(['{0}={1}'.format(x, cookies[x]) for x in cookies.keys()])
+            self._cookies_str = ';'.join(['{0}={1}'.format(x, cookies[x]) for x in cookies.keys()])
+            self._cookies = cookies
         else:
-            self._cookies = ''
+            self._cookies_str = ''
+            self._cookies = {}
 
         if headers is not None:
             if not isinstance(headers, collections_abc.Mapping):
@@ -227,7 +229,7 @@ class EventHub(object):
             # https://docs.python.org/2/library/socket.html#socket.socket.setblocking
             self._connection = websocket.create_connection(
                 url, timeout=60, sslopt={"ssl_version": available_ssl_protocol},
-                enable_multithread= True, header=self._headers, cookie=self._cookies
+                enable_multithread= True, header=self._headers, cookie=self._cookies_str
             )
 
         except Exception as error:
@@ -881,7 +883,8 @@ class EventHub(object):
                 headers={
                     'ftrack-user': self._api_user,
                     'ftrack-api-key': self._api_key
-                },
+                } | self._headers,
+                cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )
         except requests.exceptions.Timeout as error:

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -877,12 +877,13 @@ class EventHub(object):
             self.get_network_location()
         )
         try:
+            req_headers = {
+                'ftrack-user': self._api_user,
+                'ftrack-api-key': self._api_key
+            }
             response = requests.get(
                 socket_io_url,
-                headers={
-                    'ftrack-user': self._api_user,
-                    'ftrack-api-key': self._api_key
-                }.update(self._headers),
+                headers=req_headers.update(self._headers) if self._headers else req_headers,
                 cookies=self._cookies,
                 timeout=60  # 60 seconds timeout to recieve errors faster.
             )

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -249,6 +249,8 @@ class Session(object):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._request.headers.update(headers)
         
+        if not isinstance(ftrack_strict_api, bool):
+            raise TypeError('The ftrack_strict_api argument is required to be a boolean.')
         self._request.headers.update({'ftrack-strict-api': 'true' if ftrack_strict_api else 'false'})
         
         self._request.auth = SessionAuthentication(

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -85,7 +85,7 @@ class Session(object):
         self, server_url=None, api_key=None, api_user=None, auto_populate=True,
         plugin_paths=None, cache=None, cache_key_maker=None,
         auto_connect_event_hub=False, schema_cache_path=None,
-        plugin_arguments=None, timeout=60, cookies=None, headers=None
+        plugin_arguments=None, timeout=60, cookies=None, headers=None, strict_api=False
     ):
         '''Initialise session.
 
@@ -164,6 +164,10 @@ class Session(object):
 
         *headers* should be an optional mapping (dict) of key-value pairs specifying
         custom headers that we need to pass in alongside the requests to the server.
+
+        *strict_api* should be an optional boolean flag (defaulting to False if not
+        specified) indicating whether to add the 'ftrack-strict-api': 'true' header
+        to the request or not.
 
         '''
         super(Session, self).__init__()
@@ -254,6 +258,12 @@ class Session(object):
             if not isinstance(headers, collections_abc.Mapping):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._request.headers.update(headers)
+        
+        if not isinstance(strict_api, bool):
+            raise TypeError('The strict_api argument is required to be a boolean.')
+        self._request.headers.update(
+            {'ftrack-strict-api': 'true' if strict_api is True else 'false'}
+        )
         
         self._request.auth = SessionAuthentication(
             self._api_key, self._api_user

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -27,6 +27,7 @@ import warnings
 
 import requests
 import requests.auth
+import requests.utils
 import arrow
 import clique
 import appdirs
@@ -285,7 +286,9 @@ class Session(object):
         self._event_hub = ftrack_api.event.hub.EventHub(
             self._server_url,
             self._api_user,
-            self._api_key
+            self._api_key,
+            headers=self._request.headers,
+            cookies=requests.utils.dict_from_cookiejar(self._request.cookies)
         )
 
         self._auto_connect_event_hub_thread = None

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -249,9 +249,12 @@ class Session(object):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._request.headers.update(headers)
         
+        self._ftrack_strict_api = ftrack_strict_api
         if not isinstance(ftrack_strict_api, bool):
             raise TypeError('The ftrack_strict_api argument is required to be a boolean.')
-        self._request.headers.update({'ftrack-strict-api': 'true' if ftrack_strict_api else 'false'})
+        self._request.headers.update(
+            {'ftrack-strict-api': 'true' if self._ftrack_strict_api is True else 'false'}
+        )
         
         self._request.auth = SessionAuthentication(
             self._api_key, self._api_user
@@ -274,6 +277,7 @@ class Session(object):
             self._server_url,
             self._api_user,
             self._api_key,
+            ftrack_strict_api=self._ftrack_strict_api
         )
 
         self._auto_connect_event_hub_thread = None

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -85,7 +85,7 @@ class Session(object):
         self, server_url=None, api_key=None, api_user=None, auto_populate=True,
         plugin_paths=None, cache=None, cache_key_maker=None,
         auto_connect_event_hub=False, schema_cache_path=None,
-        plugin_arguments=None, timeout=60
+        plugin_arguments=None, timeout=60, cookies=None, headers=None, ftrack_strict_api=False
     ):
         '''Initialise session.
 
@@ -238,6 +238,19 @@ class Session(object):
 
         self._managed_request = None
         self._request = requests.Session()
+        
+        if cookies is not None:
+            if not isinstance(cookies, collections_abc.Mapping):
+                raise TypeError('The cookies argument is required to be a mapping.')
+            self._request.cookies.update(cookies)
+        
+        if headers is not None:
+            if not isinstance(headers, collections_abc.Mapping):
+                raise TypeError('The headers argument is required to be a mapping.')
+            self._request.headers.update(headers)
+        
+        self._request.headers.update({'ftrack-strict-api': 'true' if ftrack_strict_api else 'false'})
+        
         self._request.auth = SessionAuthentication(
             self._api_key, self._api_user
         )

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -85,7 +85,7 @@ class Session(object):
         self, server_url=None, api_key=None, api_user=None, auto_populate=True,
         plugin_paths=None, cache=None, cache_key_maker=None,
         auto_connect_event_hub=False, schema_cache_path=None,
-        plugin_arguments=None, timeout=60, cookies=None, headers=None, ftrack_strict_api=False
+        plugin_arguments=None, timeout=60, cookies=None, headers=None
     ):
         '''Initialise session.
 
@@ -158,6 +158,12 @@ class Session(object):
 
         *timeout* how long to wait for server to respond, default is 60
         seconds.
+
+        *cookies* should be an optional mapping (dict) of key-value pairs specifying
+        custom cookies that we need to pass in alongside the requests to the server.
+
+        *headers* should be an optional mapping (dict) of key-value pairs specifying
+        custom headers that we need to pass in alongside the requests to the server.
 
         '''
         super(Session, self).__init__()
@@ -249,13 +255,6 @@ class Session(object):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._request.headers.update(headers)
         
-        self._ftrack_strict_api = ftrack_strict_api
-        if not isinstance(ftrack_strict_api, bool):
-            raise TypeError('The ftrack_strict_api argument is required to be a boolean.')
-        self._request.headers.update(
-            {'ftrack-strict-api': 'true' if self._ftrack_strict_api is True else 'false'}
-        )
-        
         self._request.auth = SessionAuthentication(
             self._api_key, self._api_user
         )
@@ -276,8 +275,7 @@ class Session(object):
         self._event_hub = ftrack_api.event.hub.EventHub(
             self._server_url,
             self._api_user,
-            self._api_key,
-            ftrack_strict_api=self._ftrack_strict_api
+            self._api_key
         )
 
         self._auto_connect_event_hub_thread = None

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -184,7 +184,7 @@ def test_connect_custom_headers(session):
 def test_connect_strict_api_header(session):
     '''Connect with ftrack-strict-api = True header passed in.'''
     event_hub = ftrack_api.event.hub.EventHub(
-        session.server_url, session.api_user, session.api_key, strict_api=True}
+        session.server_url, session.api_user, session.api_key, strict_api=True
     )
     event_hub.connect()
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -173,7 +173,11 @@ def test_connect_custom_headers(session):
     )
     event_hub.connect()
 
-    assert event_hub._connection.headers == {'abc': 'def'}
+    assert (
+        'abc' in event_hub._headers.keys(),
+        event_hub._headers['abc'] == 'def',
+        event_hub.connected is True
+    )
     event_hub.disconnect()
 
 
@@ -184,7 +188,11 @@ def test_connect_ftrack_strict_api_header(session):
     )
     event_hub.connect()
 
-    assert event_hub._connection.headers == {'ftrack-strict-api': 'true'}
+    assert (
+        'ftrack-strict-api' in event_hub._headers.keys(),
+        event_hub._headers['ftrack-strict-api'] is True,
+        event_hub.connected is True
+    )
     event_hub.disconnect()
 
 
@@ -195,7 +203,10 @@ def test_connect_custom_cookies(session):
     )
     event_hub.connect()
 
-    assert event_hub._connection.cookie == 'abc=def'
+    assert (
+        event_hub._cookies == 'abc=def',
+        event_hub.connected is True
+    )
     event_hub.disconnect()
 
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -181,10 +181,10 @@ def test_connect_custom_headers(session):
     event_hub.disconnect()
 
 
-def test_connect_ftrack_strict_api_header(session):
+def test_connect_strict_api_header(session):
     '''Connect with ftrack-strict-api = True header passed in.'''
     event_hub = ftrack_api.event.hub.EventHub(
-        session.server_url, session.api_user, session.api_key, ftrack_strict_api=True
+        session.server_url, session.api_user, session.api_key, headers={'ftrack-strict-api': 'true'}
     )
     event_hub.connect()
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -166,6 +166,39 @@ def test_connect(session):
     event_hub.disconnect()
 
 
+def test_connect_custom_headers(session):
+    '''Connect with custom headers passed in.'''
+    event_hub = ftrack_api.event.hub.EventHub(
+        session.server_url, session.api_user, session.api_key, headers={'abc': 'def'}
+    )
+    event_hub.connect()
+
+    assert event_hub._connection.headers == {'abc': 'def'}
+    event_hub.disconnect()
+
+
+def test_connect_ftrack_strict_api_header(session):
+    '''Connect with ftrack-strict-api = True header passed in.'''
+    event_hub = ftrack_api.event.hub.EventHub(
+        session.server_url, session.api_user, session.api_key, ftrack_strict_api=True
+    )
+    event_hub.connect()
+
+    assert event_hub._connection.headers == {'ftrack-strict-api': 'true'}
+    event_hub.disconnect()
+
+
+def test_connect_custom_cookies(session):
+    '''Connect with custom cookies passed in.'''
+    event_hub = ftrack_api.event.hub.EventHub(
+        session.server_url, session.api_user, session.api_key, cookies={'abc': 'def'}
+    )
+    event_hub.connect()
+
+    assert event_hub._connection.cookie == 'abc=def'
+    event_hub.disconnect()
+
+
 def test_connect_when_already_connected(event_hub):
     '''Fail to connect when already connected'''
     assert event_hub.connected is True

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -184,7 +184,7 @@ def test_connect_custom_headers(session):
 def test_connect_strict_api_header(session):
     '''Connect with ftrack-strict-api = True header passed in.'''
     event_hub = ftrack_api.event.hub.EventHub(
-        session.server_url, session.api_user, session.api_key, strict_api=True
+        session.server_url, session.api_user, session.api_key, headers={'ftrack-strict-api': 'true'}
     )
     event_hub.connect()
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -184,7 +184,7 @@ def test_connect_custom_headers(session):
 def test_connect_strict_api_header(session):
     '''Connect with ftrack-strict-api = True header passed in.'''
     event_hub = ftrack_api.event.hub.EventHub(
-        session.server_url, session.api_user, session.api_key, headers={'ftrack-strict-api': 'true'}
+        session.server_url, session.api_user, session.api_key, strict_api=True}
     )
     event_hub.connect()
 

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1541,9 +1541,9 @@ def test_operation_recoding_thread_dependent(session, propagating_thread):
         assert operation.entity_key['id'] == _id
 
 
-def test_ftrack_strict_api_header():
+def test_strict_api_header():
     '''Create ftrack session containing ftrack-strict-api = True header.'''
-    new_session = ftrack_api.Session(ftrack_strict_api=True)
+    new_session = ftrack_api.Session(headers={'ftrack-strict-api': 'true'})
     
     assert(
         'ftrack-strict-api' in new_session._request.headers.keys(),

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1543,7 +1543,7 @@ def test_operation_recoding_thread_dependent(session, propagating_thread):
 
 def test_strict_api_header():
     '''Create ftrack session containing ftrack-strict-api = True header.'''
-    new_session = ftrack_api.Session(headers={'ftrack-strict-api': 'true'})
+    new_session = ftrack_api.Session(strict_api=True)
     
     assert(
         'ftrack-strict-api' in new_session._request.headers.keys(),

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1541,7 +1541,7 @@ def test_operation_recoding_thread_dependent(session, propagating_thread):
         assert operation.entity_key['id'] == _id
 
 
-def test_ftrack_strict_api():
+def test_ftrack_strict_api_header():
     '''Create ftrack session containing ftrack-strict-api = True header.'''
     new_session = ftrack_api.Session(ftrack_strict_api=True)
     

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -14,6 +14,7 @@ import pytest
 import mock
 import arrow
 import requests
+import requests.utils
 
 import ftrack_api
 import ftrack_api.cache
@@ -1538,3 +1539,34 @@ def test_operation_recoding_thread_dependent(session, propagating_thread):
 
         assert operation.entity_type == 'User'
         assert operation.entity_key['id'] == _id
+
+
+def test_ftrack_strict_api():
+    '''Create ftrack session containing ftrack-strict-api = True header.'''
+    new_session = ftrack_api.Session(ftrack_strict_api=True)
+    
+    assert(
+        'ftrack-strict-api' in new_session._request.headers.keys(),
+        new_session._request.headers['ftrack-strict-api'] == 'true'
+    )
+
+
+def test_custom_cookies_session():
+    '''Create ftrack session containing custom cookies.'''
+    new_session = ftrack_api.Session(cookies={'abc': 'def'})
+    cookies_dict = requests.utils.dict_from_cookiejar(new_session._request.cookies)
+
+    assert(
+        'abc' in cookies_dict.keys(),
+        cookies_dict['abc'] == 'def'
+    )
+
+
+def test_custom_headers_session():
+    '''Create ftrack session containing custom headers.'''
+    new_session = ftrack_api.Session(headers={'abc': 'def'})
+
+    assert(
+        'abc' in new_session._request.headers.keys(),
+        new_session._request.headers['abc'] == 'def'
+    )   


### PR DESCRIPTION
Resolves FT-57b865d0-9cb0-11ed-8932-ae41419580c7

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [x] I have verified that the documentation is still up to date.

## Changes
added possibility for the user to specify own headers, cookies and the ftrack-strict-api header, when creating a new Session object and in the case of a new EventHub connection.
## Test
unit tests cover this functionality. If manual testing is required, simply use httpbin/headers and/or httpbin/cookies, respectively:

```
new_session = ftrack_api.Session(cookies={'abc': 'def'})
cookies_dict = requests.utils.dict_from_cookiejar(new_session._request.cookies)
new_response = new_session._request.get('https://httpbin.org/cookies')
assert (
        'abc' in new_response.json()['cookies'].keys(),
        new_response.json()['cookies']['abc'] == 'def'
)
```


```
new_session = ftrack_api.Session(headers={'abc': 'def'})
new_response = new_session._request.get('https://httpbin.org/headers')
assert (
    'abc'.capitalize() in new_response.json()['headers'].keys(),
    new_response.json()['headers']['abc'.capitalize()] == 'def'
)
```