### PR TITLE
fix: Add note about release notes

### DIFF
--- a/doc/release/index.rst
+++ b/doc/release/index.rst
@@ -7,6 +7,11 @@
 Release and migration notes
 ***************************
 
+.. note::
+
+    Release notes for new versions are published in GitHub at the following
+    URL: https://github.com/ftrackhq/ftrack-python/releases
+
 Find out information about what has changed between versions and any important
 migration notes to be aware of when switching to a new version.
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,11 @@ Release Notes
 
 .. currentmodule:: ftrack_api.session
 
+.. note::
+
+    Release notes for new versions are published in GitHub at the following
+    URL: https://github.com/ftrackhq/ftrack-python/releases
+
 .. release:: Upcoming
 
     .. change:: changed


### PR DESCRIPTION
## Changes
Adds note about release notes now being published on github instead.

