### PR TITLE
chor: python 3.10 and 3.11 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     services:

--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,11 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
 
     ],
     zip_safe=False,
-    python_requires=">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, < 3.10"
+    python_requires=">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 )


### PR DESCRIPTION
Resolves FT-2b961ef8-a87b-11ed-9616-1a399e0e5bff

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [x] I have verified that the documentation is still up to date.

## Changes
1. Update package to reflect supported python versions.
2. Update workflows to test against 3.10 and 3.11 as well.


