### PR TITLE
chor: document Session auto_connect_event_hub behavior

### DIFF
--- a/doc/handling_events.rst
+++ b/doc/handling_events.rst
@@ -49,7 +49,7 @@ events and then print out the entities that were updated::
 
 
     # Subscribe to events with the update topic.
-    session = ftrack_api.Session()
+    session = ftrack_api.Session(auto_connect_event_hub=True)
     session.event_hub.subscribe('topic=ftrack.update', my_callback)
 
 At this point, if you run this, your code would exit almost immediately. This
@@ -153,7 +153,7 @@ allows handlers to prevent lower priority handlers running when desired.
     ...     '''Never run.'''
     ...     print('Callback B')
     >>>
-    >>> session = ftrack_api.Session()
+    >>> session = ftrack_api.Session(auto_connect_event_hub=True)
     >>> session.event_hub.subscribe(
     ...     'topic=test-stop-event', callback_a, priority=10
     ... )
@@ -221,7 +221,7 @@ returned together in a list::
     >>> def callback_b(event):
     ...     return 'B'
     >>>
-    >>> session = ftrack_api.Session()
+    >>> session = ftrack_api.Session(auto_connect_event_hub=True)
     >>> session.event_hub.subscribe(
     ...     'topic=test-synchronous', callback_a, priority=10
     ... )


### PR DESCRIPTION
- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [x] I have verified that the documentation is still up to date.

## Changes

The code examples in the Handling Events section of the documentation didn't include the `auto_connect_event_hub=True` parameter because that was the default in older versions of the API. As such, the example code would never work now that the default value is `False`.

## Test

Doc change only. No tests.
