### PR TITLE
fix: Check for errors before parsing api json response

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - closed
+      - converted_to_draft
+      - ready_for_review
+jobs:
+  check-pr:
+    name: Check PR
+    uses: ftrackhq/ftrack-actions/.github/workflows/pr-base.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      ftrackApiKey: ${{ secrets.FTRACK_API_KEY }}


### PR DESCRIPTION
Resolves FT-38746011-2443-478e-990a-e8507efad720

- [ ] I have added automatic tests where applicable.
- [X] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Add a check for error statuses before parsing json response, which fails otherwise since errors are not json formated. 
## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
