### PR TITLE
fix: incomplete/incorrect headers sent when establishing event hub connection

### DIFF
--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -126,9 +126,16 @@ class EventHub(object):
             url_parse_result.hostname,
             url_parse_result.port
         )
-        
-        self._cookies = cookies or {}
-        self._headers = headers or {}
+
+        def _validate_mapping(mapping):
+            '''Validate mapping is a mapping type and return as dict.'''
+            if not isinstance(mapping, collections_abc.Mapping):
+                raise TypeError('Expected mapping, got {0!r}.'.format(mapping))
+
+            return dict(mapping)
+
+        self._cookies = _validate_mapping(cookies or {})
+        self._headers = _validate_mapping(headers or {})
 
     def get_server_url(self):
         '''Return URL to server.'''

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -250,18 +250,17 @@ class Session(object):
         self._managed_request = None
         self._request = requests.Session()
         
-        if cookies is not None:
+        if cookies:
             if not isinstance(cookies, collections_abc.Mapping):
                 raise TypeError('The cookies argument is required to be a mapping.')
             self._request.cookies.update(cookies)
-        
-        if headers is not None:
+
+        if headers:
             if not isinstance(headers, collections_abc.Mapping):
                 raise TypeError('The headers argument is required to be a mapping.')
 
             headers = dict(headers)
 
-            self._request.headers.update(headers)
         else:
             headers = {}
         
@@ -271,7 +270,8 @@ class Session(object):
         headers.update(
             {'ftrack-strict-api': 'true' if strict_api is True else 'false'}
         )
-        
+
+        self._request.headers.update(headers)
         self._request.auth = SessionAuthentication(
             self._api_key, self._api_user
         )

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -258,12 +258,16 @@ class Session(object):
         if headers is not None:
             if not isinstance(headers, collections_abc.Mapping):
                 raise TypeError('The headers argument is required to be a mapping.')
+
+            headers = dict(headers)
+
             self._request.headers.update(headers)
         else:
             headers = {}
         
         if not isinstance(strict_api, bool):
             raise TypeError('The strict_api argument is required to be a boolean.')
+
         headers.update(
             {'ftrack-strict-api': 'true' if strict_api is True else 'false'}
         )

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -259,10 +259,12 @@ class Session(object):
             if not isinstance(headers, collections_abc.Mapping):
                 raise TypeError('The headers argument is required to be a mapping.')
             self._request.headers.update(headers)
+        else:
+            headers = {}
         
         if not isinstance(strict_api, bool):
             raise TypeError('The strict_api argument is required to be a boolean.')
-        self._request.headers.update(
+        headers.update(
             {'ftrack-strict-api': 'true' if strict_api is True else 'false'}
         )
         
@@ -287,7 +289,7 @@ class Session(object):
             self._server_url,
             self._api_user,
             self._api_key,
-            headers=self._request.headers,
+            headers=headers,
             cookies=requests.utils.dict_from_cookiejar(self._request.cookies)
         )
 

--- a/test/unit/event/test_hub.py
+++ b/test/unit/event/test_hub.py
@@ -7,6 +7,7 @@ import os
 import time
 import subprocess
 import sys
+import requests
 import logging
 
 import pytest
@@ -181,15 +182,28 @@ def test_connect_custom_headers(session):
     event_hub.disconnect()
 
 
-def test_connect_strict_api_header(session):
+@pytest.mark.parametrize(
+    'headers', [
+        (
+            requests.structures.CaseInsensitiveDict(
+                {'ftrack-strict-api': 'true'}
+            )
+        ),
+        (
+            {'ftrack-strict-api': 'true'}
+        )
+    ]
+)
+def test_connect_strict_api_header(session, headers):
     '''Connect with ftrack-strict-api = True header passed in.'''
     event_hub = ftrack_api.event.hub.EventHub(
-        session.server_url, session.api_user, session.api_key, headers={'ftrack-strict-api': 'true'}
+        session.server_url, session.api_user, session.api_key, headers=headers
     )
     event_hub.connect()
 
     assert (
         'ftrack-strict-api' in event_hub._headers.keys(),
+        isinstance(event_hub._headers, dict),
         event_hub._headers['ftrack-strict-api'] is True,
         event_hub.connected is True
     )


### PR DESCRIPTION
Resolves FT-6c5e6756-1253-4eac-985b-d759a4b5d71a

- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes

Incomplete / malformed headers were being generated for websocket connections. This caused some ingress controllers to throw an error.

```
Upgrade: websocket
Host: k3s-terraform.ftrackapp.com
Origin: http://k3s-terraform.ftrackapp.com/
Sec-WebSocket-Key: qPLLoRR9cZjCDlc6Jz6L3w==
Sec-WebSocket-Version: 13
Connection: Upgrade
User-Agent
Accept-Encoding
Accept
Connection
ftrack-strict-api
```
## Test
Ensure that the headers present in the websocket connection / handshake are complete