### PR TITLE
chore: remove termcolor 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
     install_requires=[
         'requests >= 2, <3',
         'arrow >= 0.4.4, < 1',
-        'termcolor >= 1.1.0, < 2',
         'pyparsing >= 2.0, < 3',
         'clique == 1.6.1',
         'websocket-client >= 0.40.0, < 1',
@@ -88,6 +87,7 @@ setup(
     ],
     tests_require=[
         'pytest >= 4.6',
+        'termcolor >= 1.1.0, < 2',
         'pytest-mock',
         'mock',
         'flaky'

--- a/source/ftrack_api/formatter.py
+++ b/source/ftrack_api/formatter.py
@@ -1,5 +1,7 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014 ftrack
+import os
+import sys
 
 from builtins import str
 
@@ -15,6 +17,21 @@ FILTER = {
         lambda entity, name, value: value is not ftrack_api.symbol.NOT_SET
     )
 }
+
+
+def _can_do_colors():
+    '''check if we are ( likely ) to be able to handle colors.'''
+    if "ANSI_COLORS_DISABLED" in os.environ:
+        return False
+    if "NO_COLOR" in os.environ:
+        return False
+    if "FORCE_COLOR" in os.environ:
+        return True
+    return (
+        hasattr(sys.stdout, "isatty")
+        and sys.stdout.isatty()
+        and os.environ.get("TERM") != "dumb"
+    )
 
 
 def format(
@@ -55,10 +72,12 @@ def format(
         formatters = dict()
 
     formatters.setdefault(
-        'header', lambda text: '\x1b[1m\x1b[44m\x1b[97m{}\x1b[0m'.format(text)
+        'header',
+        lambda text: '\x1b[1m\x1b[44m\x1b[97m{}\x1b[0m\033[0m'.format(text) if _can_do_colors() else text
     )
     formatters.setdefault(
-        'label', lambda text: '\x1b[1m\x1b[34m{}\x1b[0m'.format(text)
+        'label',
+        lambda text: '\x1b[1m\x1b[34m{}\x1b[0m\033[0m'.format(text) if _can_do_colors() else text
     )
 
     # Determine indents.

--- a/source/ftrack_api/formatter.py
+++ b/source/ftrack_api/formatter.py
@@ -58,7 +58,7 @@ def format(
         'header', lambda text: '\x1b[1m\x1b[44m\x1b[97m{}\x1b[0m'.format(text)
     )
     formatters.setdefault(
-        'label', lambda text: '\x1b[1m\x1b[34mJJJJJ\x1b[0m'.format(text)
+        'label', lambda text: '\x1b[1m\x1b[34m{}\x1b[0m'.format(text)
     )
 
     # Determine indents.

--- a/source/ftrack_api/formatter.py
+++ b/source/ftrack_api/formatter.py
@@ -2,7 +2,6 @@
 # :copyright: Copyright (c) 2014 ftrack
 
 from builtins import str
-import termcolor
 
 import ftrack_api.entity.base
 import ftrack_api.collection
@@ -56,14 +55,10 @@ def format(
         formatters = dict()
 
     formatters.setdefault(
-        'header', lambda text: termcolor.colored(
-            text, 'white', 'on_blue', attrs=['bold']
-        )
+        'header', lambda text: '\x1b[1m\x1b[44m\x1b[97m{}\x1b[0m'.format(text)
     )
     formatters.setdefault(
-        'label', lambda text: termcolor.colored(
-            text, 'blue', attrs=['bold']
-        )
+        'label', lambda text: '\x1b[1m\x1b[34mJJJJJ\x1b[0m'.format(text)
     )
 
     # Determine indents.


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * FT-d370864e-f02f-47b8-9945-1e2d0bd86ca5
  * SENTRY-
  * ZENDESK-

-->

Resolves FT-d370864e-f02f-47b8-9945-1e2d0bd86ca5

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
remove `termcolor` as a dependency.

## Test
ensure `ftrack_api.formatter.format` behaves as expected.