### PR TITLE
fix: incomplete documentation builds

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,7 +69,7 @@ html_copy_source = True
 
 # -- Autodoc ------------------------------------------------------------------
 
-autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
+autodoc_default_options = {"members": None, 'undoc-members': None, 'inherited-members': None}
 autodoc_member_order = 'bysource'
 
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -8,3 +8,5 @@ build:
 python:
   install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
- [x] autodoc_default_flags is deprecated update to autodoc_default_options. 
- [x]ensure ftrack_api is installed and available
## Test


https://ftrack-python-api.readthedocs.io/en/backlog-missing-package-for-automodule/api_reference/exception.html