### PR TITLE
feat: python 3.12 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/source/ftrack_api/cache.py
+++ b/source/ftrack_api/cache.py
@@ -15,19 +15,15 @@ memoisation of function using a global cache and standard key maker.
 
 '''
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from six import string_types
 from builtins import object
-import collections
 from six.moves import collections_abc
 import functools
 import abc
 import copy
 import inspect
 import re
-import six
 
 try:
     # Python 2.x

--- a/source/ftrack_api/event/hub.py
+++ b/source/ftrack_api/event/hub.py
@@ -3,8 +3,6 @@
 
 from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/source/ftrack_api/plugin.py
+++ b/source/ftrack_api/plugin.py
@@ -56,7 +56,10 @@ except ImportError:
             importlib.util.spec_from_file_location(modname, filename, loader=loader)
         )
 
-        return loader.exec_module(module)
+        loader.exec_module(module)
+
+        return module
+
 
 def discover(paths, positional_arguments=None, keyword_arguments=None):
     '''Find and load plugins in search *paths*.

--- a/source/ftrack_api/plugin.py
+++ b/source/ftrack_api/plugin.py
@@ -41,6 +41,23 @@ except ImportError:
             annotations={}
         )
 
+try:
+    from imp import load_source
+
+except ImportError:
+    # The imp module is deprecated in version 3.12. Use importlib instead.
+    import importlib.util
+    import importlib.machinery
+
+    def load_source(modname, filename):
+        # https://docs.python.org/3/whatsnew/3.12.html#imp
+
+        loader = importlib.machinery.SourceFileLoader(modname, filename)
+        module = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location(modname, filename, loader=loader)
+        )
+
+        return loader.exec_module(module)
 
 def discover(paths, positional_arguments=None, keyword_arguments=None):
     '''Find and load plugins in search *paths*.
@@ -77,7 +94,7 @@ def discover(paths, positional_arguments=None, keyword_arguments=None):
                 unique_name = uuid.uuid4().hex
 
                 try:
-                    module = imp.load_source(unique_name, module_path)
+                    module = load_source(unique_name, module_path)
                 except Exception as error:
                     logger.warning(
                         'Failed to load plugin from "{0}": {1}'

--- a/source/ftrack_api/plugin.py
+++ b/source/ftrack_api/plugin.py
@@ -7,7 +7,6 @@ import logging
 import collections
 import os
 import uuid
-import imp
 import traceback
 
 try:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * 
  * SENTRY-
  * ZENDESK-

-->

Resolves FT-d8bd8146-a803-474c-86ca-9a31e7ddbdcb

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
Ensure support for python 3.12

- replace deprecated `imp` module ( https://docs.python.org/3/whatsnew/3.12.html#imp ) 
- test towards 3.12
- remove future.standard_library

## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
