### PR TITLE
chore: Backlog/remove distutils dependency

### DIFF
--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -444,7 +444,8 @@ class Session(object):
                 return
 
             min_server_version = (3, 3, 11)
-            if tuple(map(int, match.groups())) < min_server_version:
+            server_version = tuple(map(int, match.groups()))
+            if server_version < min_server_version:
                 raise ftrack_api.exception.ServerCompatibilityError(
                     "Server version {0} incompatible with this version of the "
                     "API which requires a server version >= {1}".format(

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -18,7 +18,6 @@ import os
 import getpass
 import functools
 import itertools
-import distutils.version
 import hashlib
 import tempfile
 import threading
@@ -438,10 +437,14 @@ class Session(object):
 
         # Perform basic version check.
         if server_version != "dev":
-            min_server_version = "3.3.11"
-            if distutils.version.LooseVersion(
-                min_server_version
-            ) > distutils.version.LooseVersion(server_version):
+            import re
+
+            match = re.match(r"(\d+)\.(\d+)\.(\d+)", server_version)
+            if not match:
+                return
+
+            min_server_version = (3, 3, 11)
+            if tuple(map(int, match.groups())) < min_server_version:
                 raise ftrack_api.exception.ServerCompatibilityError(
                     "Server version {0} incompatible with this version of the "
                     "API which requires a server version >= {1}".format(


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * 
  * SENTRY-
  * ZENDESK-

-->

Resolves FT-5205acef-02a9-40ae-8521-50df99d394fc

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
remove dependence on deprecated `ditstutils.version`

## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
