### PR TITLE
chore: update from deprecated v2 of upload artifacts.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,7 +67,7 @@ jobs:
           poetry install --only=dev --no-interaction
           poetry build --format=wheel
           poetry run twine check dist/*
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Download package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -112,7 +112,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Download package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1019,7 +1019,7 @@ def test_fail_to_read_schemas_from_invalid_cache(
 
 def test_write_schemas_to_cache(session, temporary_valid_schema_cache):
     """Write valid content to schema cache."""
-    expected_hash = "a98d0627b5e33966e43e1cb89b082db7"
+    expected_hash = "c8f8bdc59c415a5a96339647e45b751b"
     schemas, _ = session._read_schemas_from_cache(temporary_valid_schema_cache)
 
     session._write_schemas_to_cache(schemas, temporary_valid_schema_cache)

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1019,7 +1019,7 @@ def test_fail_to_read_schemas_from_invalid_cache(
 
 def test_write_schemas_to_cache(session, temporary_valid_schema_cache):
     """Write valid content to schema cache."""
-    expected_hash = "c8f8bdc59c415a5a96339647e45b751b"
+    expected_hash = "a98d0627b5e33966e43e1cb89b082db7"
     schemas, _ = session._read_schemas_from_cache(temporary_valid_schema_cache)
 
     session._write_schemas_to_cache(schemas, temporary_valid_schema_cache)


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
update upload artifacts action ( https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ ) 
## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
