### PR TITLE
fix: threadsafe session sharing across threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-python-api"
-version = "0.1.0"
+version = "3.0.5.rc1"
 description = "Python API for ftrack."
 authors = ["ftrack <support@ftrack.com>"]
 repository = "https://github.com/ftrackhq/ftrack-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-python-api"
-version = "3.0.5.rc1"
+version = "0.1.0"
 description = "Python API for ftrack."
 authors = ["ftrack <support@ftrack.com>"]
 repository = "https://github.com/ftrackhq/ftrack-python"

--- a/source/ftrack_api/query.py
+++ b/source/ftrack_api/query.py
@@ -10,8 +10,8 @@ import ftrack_api.exception
 class QueryResult(collections.abc.Sequence):
     """Results from a query."""
 
-    OFFSET_EXPRESSION = re.compile("(?P<offset>offset (?P<value>\d+))")
-    LIMIT_EXPRESSION = re.compile("(?P<limit>limit (?P<value>\d+))")
+    OFFSET_EXPRESSION = re.compile(r"(?P<offset>offset (?P<value>\d+))")
+    LIMIT_EXPRESSION = re.compile(r"(?P<limit>limit (?P<value>\d+))")
 
     def __init__(self, session, expression, page_size=500):
         """Initialise result set.

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -55,8 +55,8 @@ from ftrack_api.logging import LazyLogMessage as L
 from weakref import WeakMethod
 
 
-def synchronous(func):
-    """Decorator to synchronize access to a method or function."""
+def _synchronous(func):
+    """Decorator to synchronize access to a method or function across threads."""
     lock = threading.RLock()
 
     def wrapper(*args, **kwargs):
@@ -902,7 +902,7 @@ class Session(object):
         with self.operation_recording(False):
             return self._merge(value, merged)
 
-    @synchronous
+    @_synchronous
     def _merge(self, value, merged):
         """Return merged *value*."""
         log_debug = self.logger.isEnabledFor(logging.DEBUG)
@@ -1155,8 +1155,7 @@ class Session(object):
             # actually populated? If some weren't would we mark that to avoid
             # repeated calls or perhaps raise an error?
 
-    # TODO: Make atomic.
-    @synchronous
+    @_synchronous
     def commit(self):
         """Commit all local changes to the server."""
         batch = []
@@ -1337,7 +1336,7 @@ class Session(object):
                     for entity in list(self._local_cache.values()):
                         entity.clear()
 
-    @synchronous
+    @_synchronous
     def rollback(self):
         """Clear all recorded operations and local state.
 

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -178,7 +178,6 @@ class Session(object):
         super(Session, self).__init__()
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
         self._closed = False
-        self._thread_lock = threading.RLock()
 
         if server_url is None:
             server_url = os.environ.get("FTRACK_SERVER")
@@ -242,6 +241,7 @@ class Session(object):
             if cache is not None:
                 self.cache.caches.append(cache)
 
+        self._thread_lock = threading.RLock()
         self._managed_request = None
         self._request = requests.Session()
 

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -54,13 +54,17 @@ from ftrack_api.logging import LazyLogMessage as L
 
 from weakref import WeakMethod
 
+
 def synchronous(func):
-    """ Decorator to synchronize access to a method or function."""
+    """Decorator to synchronize access to a method or function."""
     lock = threading.RLock()
+
     def wrapper(*args, **kwargs):
         with lock:
             return func(*args, **kwargs)
+
     return wrapper
+
 
 class SessionAuthentication(requests.auth.AuthBase):
     """Attach ftrack session authentication information to requests."""
@@ -912,9 +916,7 @@ class Session(object):
 
         elif isinstance(value, ftrack_api.collection.Collection):
             log_debug and self.logger.debug(
-                "Merging collection into session: {0!r} at {1}".format(
-                    value, id(value)
-                )
+                "Merging collection into session: {0!r} at {1}".format(value, id(value))
             )
 
             merged_collection = []

--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -1151,192 +1151,183 @@ class Session(object):
         """Commit all local changes to the server."""
         batch = []
 
-        with self._thread_lock:
-            with self.auto_populating(False):
-                for operation in self.recorded_operations:
-                    # Convert operation to payload.
-                    if isinstance(
-                        operation, ftrack_api.operation.CreateEntityOperation
-                    ):
+        with self._thread_lock, self.auto_populating(False):
+            for operation in self.recorded_operations:
+                # Convert operation to payload.
+                if isinstance(operation, ftrack_api.operation.CreateEntityOperation):
+                    # At present, data payload requires duplicating entity
+                    # type in data and also ensuring primary key added.
+                    entity_data = {
+                        "__entity_type__": operation.entity_type,
+                    }
+                    entity_data.update(operation.entity_key)
+                    entity_data.update(operation.entity_data)
+
+                    payload = OperationPayload(
+                        {
+                            "action": "create",
+                            "entity_type": operation.entity_type,
+                            "entity_key": list(operation.entity_key.values()),
+                            "entity_data": entity_data,
+                        }
+                    )
+
+                elif isinstance(operation, ftrack_api.operation.UpdateEntityOperation):
+                    entity_data = {
                         # At present, data payload requires duplicating entity
-                        # type in data and also ensuring primary key added.
-                        entity_data = {
-                            "__entity_type__": operation.entity_type,
+                        # type.
+                        "__entity_type__": operation.entity_type,
+                        operation.attribute_name: operation.new_value,
+                    }
+
+                    payload = OperationPayload(
+                        {
+                            "action": "update",
+                            "entity_type": operation.entity_type,
+                            "entity_key": list(operation.entity_key.values()),
+                            "entity_data": entity_data,
                         }
-                        entity_data.update(operation.entity_key)
-                        entity_data.update(operation.entity_data)
+                    )
 
-                        payload = OperationPayload(
-                            {
-                                "action": "create",
-                                "entity_type": operation.entity_type,
-                                "entity_key": list(operation.entity_key.values()),
-                                "entity_data": entity_data,
-                            }
-                        )
-
-                    elif isinstance(
-                        operation, ftrack_api.operation.UpdateEntityOperation
-                    ):
-                        entity_data = {
-                            # At present, data payload requires duplicating entity
-                            # type.
-                            "__entity_type__": operation.entity_type,
-                            operation.attribute_name: operation.new_value,
+                elif isinstance(operation, ftrack_api.operation.DeleteEntityOperation):
+                    payload = OperationPayload(
+                        {
+                            "action": "delete",
+                            "entity_type": operation.entity_type,
+                            "entity_key": list(operation.entity_key.values()),
                         }
+                    )
 
-                        payload = OperationPayload(
-                            {
-                                "action": "update",
-                                "entity_type": operation.entity_type,
-                                "entity_key": list(operation.entity_key.values()),
-                                "entity_data": entity_data,
-                            }
-                        )
+                else:
+                    raise ValueError(
+                        "Cannot commit. Unrecognised operation type {0} "
+                        "detected.".format(type(operation))
+                    )
 
-                    elif isinstance(
-                        operation, ftrack_api.operation.DeleteEntityOperation
-                    ):
-                        payload = OperationPayload(
-                            {
-                                "action": "delete",
-                                "entity_type": operation.entity_type,
-                                "entity_key": list(operation.entity_key.values()),
-                            }
-                        )
+                batch.append(payload)
 
-                    else:
-                        raise ValueError(
-                            "Cannot commit. Unrecognised operation type {0} "
-                            "detected.".format(type(operation))
-                        )
+        # Optimise batch.
+        # TODO: Might be better to perform these on the operations list instead
+        # so all operation contextual information available.
 
-                    batch.append(payload)
+        # If entity was created and deleted in one batch then remove all
+        # payloads for that entity.
+        created = set()
+        deleted = set()
 
-            # Optimise batch.
-            # TODO: Might be better to perform these on the operations list instead
-            # so all operation contextual information available.
+        for payload in batch:
+            if payload["action"] == "create":
+                created.add((payload["entity_type"], str(payload["entity_key"])))
 
-            # If entity was created and deleted in one batch then remove all
-            # payloads for that entity.
-            created = set()
-            deleted = set()
+            elif payload["action"] == "delete":
+                deleted.add((payload["entity_type"], str(payload["entity_key"])))
 
-            for payload in batch:
-                if payload["action"] == "create":
-                    created.add((payload["entity_type"], str(payload["entity_key"])))
-
-                elif payload["action"] == "delete":
-                    deleted.add((payload["entity_type"], str(payload["entity_key"])))
-
-            created_then_deleted = deleted.intersection(created)
-            if created_then_deleted:
-                optimised_batch = []
-                for payload in batch:
-                    entity_type = payload.get("entity_type")
-                    entity_key = str(payload.get("entity_key"))
-
-                    if (entity_type, entity_key) in created_then_deleted:
-                        continue
-
-                    optimised_batch.append(payload)
-
-                batch = optimised_batch
-
-            # Remove early update operations so that only last operation on
-            # attribute is applied server side.
-            updates_map = set()
-            for payload in reversed(batch):
-                if payload["action"] in ("update",):
-                    for key, value in list(payload["entity_data"].items()):
-                        if key == "__entity_type__":
-                            continue
-
-                        identity = (
-                            payload["entity_type"],
-                            str(payload["entity_key"]),
-                            key,
-                        )
-                        if identity in updates_map:
-                            del payload["entity_data"][key]
-                        else:
-                            updates_map.add(identity)
-
-            # Remove NOT_SET values from entity_data.
-            for payload in batch:
-                entity_data = payload.get("entity_data", {})
-                for key, value in list(entity_data.items()):
-                    if value is ftrack_api.symbol.NOT_SET:
-                        del entity_data[key]
-
-            # Remove payloads with redundant entity_data.
+        created_then_deleted = deleted.intersection(created)
+        if created_then_deleted:
             optimised_batch = []
             for payload in batch:
-                entity_data = payload.get("entity_data")
-                if entity_data is not None:
-                    keys = list(entity_data.keys())
-                    if not keys or keys == ["__entity_type__"]:
-                        continue
+                entity_type = payload.get("entity_type")
+                entity_key = str(payload.get("entity_key"))
+
+                if (entity_type, entity_key) in created_then_deleted:
+                    continue
 
                 optimised_batch.append(payload)
 
             batch = optimised_batch
 
-            # Collapse updates that are consecutive into one payload. Also, collapse
-            # updates that occur immediately after creation into the create payload.
-            optimised_batch = []
-            previous_payload = None
+        # Remove early update operations so that only last operation on
+        # attribute is applied server side.
+        updates_map = set()
+        for payload in reversed(batch):
+            if payload["action"] in ("update",):
+                for key, value in list(payload["entity_data"].items()):
+                    if key == "__entity_type__":
+                        continue
 
-            for payload in batch:
-                if (
-                    previous_payload is not None
-                    and payload["action"] == "update"
-                    and previous_payload["action"] in ("create", "update")
-                    and previous_payload["entity_type"] == payload["entity_type"]
-                    and previous_payload["entity_key"] == payload["entity_key"]
-                ):
-                    previous_payload["entity_data"].update(payload["entity_data"])
+                    identity = (
+                        payload["entity_type"],
+                        str(payload["entity_key"]),
+                        key,
+                    )
+                    if identity in updates_map:
+                        del payload["entity_data"][key]
+                    else:
+                        updates_map.add(identity)
+
+        # Remove NOT_SET values from entity_data.
+        for payload in batch:
+            entity_data = payload.get("entity_data", {})
+            for key, value in list(entity_data.items()):
+                if value is ftrack_api.symbol.NOT_SET:
+                    del entity_data[key]
+
+        # Remove payloads with redundant entity_data.
+        optimised_batch = []
+        for payload in batch:
+            entity_data = payload.get("entity_data")
+            if entity_data is not None:
+                keys = list(entity_data.keys())
+                if not keys or keys == ["__entity_type__"]:
                     continue
 
-                else:
-                    optimised_batch.append(payload)
-                    previous_payload = payload
+            optimised_batch.append(payload)
 
-            batch = optimised_batch
+        batch = optimised_batch
 
-            # Process batch.
-            if batch:
-                result = self.call(batch)
+        # Collapse updates that are consecutive into one payload. Also, collapse
+        # updates that occur immediately after creation into the create payload.
+        optimised_batch = []
+        previous_payload = None
 
-                # Clear recorded operations.
-                self.recorded_operations.clear()
+        for payload in batch:
+            if (
+                previous_payload is not None
+                and payload["action"] == "update"
+                and previous_payload["action"] in ("create", "update")
+                and previous_payload["entity_type"] == payload["entity_type"]
+                and previous_payload["entity_key"] == payload["entity_key"]
+            ):
+                previous_payload["entity_data"].update(payload["entity_data"])
+                continue
 
-                # As optimisation, clear local values which are not primary keys to
-                # avoid redundant merges when merging references. Note: primary keys
-                # remain as needed for cache retrieval on new entities.
-                with self.auto_populating(False):
-                    with self.operation_recording(False):
-                        for entity in list(self._local_cache.values()):
-                            for attribute in entity:
-                                if attribute not in entity.primary_key_attributes:
-                                    del entity[attribute]
+            else:
+                optimised_batch.append(payload)
+                previous_payload = payload
 
-                # Process results merging into cache relevant data.
-                for entry in result:
-                    if entry["action"] in ("create", "update"):
-                        # Merge returned entities into local cache.
-                        self.merge(entry["data"])
+        batch = optimised_batch
 
-                    elif entry["action"] == "delete":
-                        # TODO: Detach entity - need identity returned?
-                        # TODO: Expunge entity from cache.
-                        pass
-                # Clear remaining local state, including local values for primary
-                # keys on entities that were merged.
-                with self.auto_populating(False):
-                    with self.operation_recording(False):
-                        for entity in list(self._local_cache.values()):
-                            entity.clear()
+        # Process batch.
+        if batch:
+            result = self.call(batch)
+
+            # Clear recorded operations.
+            self.recorded_operations.clear()
+
+            # As optimisation, clear local values which are not primary keys to
+            # avoid redundant merges when merging references. Note: primary keys
+            # remain as needed for cache retrieval on new entities.
+            with self.auto_populating(False), self.operation_recording(False):
+                for entity in list(self._local_cache.values()):
+                    for attribute in entity:
+                        if attribute not in entity.primary_key_attributes:
+                            del entity[attribute]
+
+            # Process results merging into cache relevant data.
+            for entry in result:
+                if entry["action"] in ("create", "update"):
+                    # Merge returned entities into local cache.
+                    self.merge(entry["data"])
+
+                elif entry["action"] == "delete":
+                    # TODO: Detach entity - need identity returned?
+                    # TODO: Expunge entity from cache.
+                    pass
+            # Clear remaining local state, including local values for primary
+            # keys on entities that were merged.
+            with self.auto_populating(False), self.operation_recording(False):
+                for entity in list(self._local_cache.values()):
+                    entity.clear()
 
     def rollback(self):
         """Clear all recorded operations and local state.
@@ -1351,32 +1342,31 @@ class Session(object):
 
         """
         with self._thread_lock:
-            with self.auto_populating(False):
-                with self.operation_recording(False):
-                    # Detach all newly created entities and remove from cache. This
-                    # is done because simply clearing the local values of newly
-                    # created entities would result in entities with no identity as
-                    # primary key was local while not persisted. In addition, it
-                    # makes no sense for failed created entities to exist in session
-                    # or cache.
-                    for operation in self.recorded_operations:
-                        if isinstance(
-                            operation, ftrack_api.operation.CreateEntityOperation
-                        ):
-                            entity_key = str(
-                                (
-                                    str(operation.entity_type),
-                                    list(operation.entity_key.values()),
-                                )
+            with self.auto_populating(False), self.operation_recording(False):
+                # Detach all newly created entities and remove from cache. This
+                # is done because simply clearing the local values of newly
+                # created entities would result in entities with no identity as
+                # primary key was local while not persisted. In addition, it
+                # makes no sense for failed created entities to exist in session
+                # or cache.
+                for operation in self.recorded_operations:
+                    if isinstance(
+                        operation, ftrack_api.operation.CreateEntityOperation
+                    ):
+                        entity_key = str(
+                            (
+                                str(operation.entity_type),
+                                list(operation.entity_key.values()),
                             )
-                            try:
-                                self.cache.remove(entity_key)
-                            except KeyError:
-                                pass
+                        )
+                        try:
+                            self.cache.remove(entity_key)
+                        except KeyError:
+                            pass
 
-                    # Clear locally stored modifications on remaining entities.
-                    for entity in list(self._local_cache.values()):
-                        entity.clear()
+                # Clear locally stored modifications on remaining entities.
+                for entity in list(self._local_cache.values()):
+                    entity.clear()
 
             self.recorded_operations.clear()
 


### PR DESCRIPTION
Make the session commits and rollbacks threadsafe via a lock that makes these database operations synchronous.

Resolves F-318

- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
- fix minor problem with regex patterns not being raw strings (this lead to unknown escape sequence errors in newer python versions)
- guard the `commit`, `rollback` and `merge` Session functionality with `_thread_lock` context manager
- 
## Test
- run automated tests
