### PR TITLE
fix: ensure publish jobs pick up the correct tag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,7 +81,14 @@ jobs:
       name: staging
       url: https://test.pypi.org/project/ftrack-python-api/
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout workflow-triggering tag
+        run: |
+          git fetch --tags
+          git checkout "${GITHUB_REF_NAME}"
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -106,7 +113,14 @@ jobs:
       name: production
       url: https://pypi.org/project/ftrack-python-api/
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout workflow-triggering tag
+        run: |
+          git fetch --tags
+          git checkout "${GITHUB_REF_NAME}"
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,7 +87,6 @@ jobs:
           fetch-depth: 0
       - name: Checkout workflow-triggering tag
         run: |
-          git fetch --tags
           git checkout "${GITHUB_REF_NAME}"
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -119,7 +118,6 @@ jobs:
           fetch-depth: 0
       - name: Checkout workflow-triggering tag
         run: |
-          git fetch --tags
           git checkout "${GITHUB_REF_NAME}"
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Resolves [F-451](https://linear.app/iconik/issue/F-451/fix-python-api-release)

- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
- used `checkout@v4` instead of v1, with `fetch-depth: 0` to fetch all available tags, then added an intermediary step to `git checkout ${GITHUB_REF_NAME}` which should be populated with the correct, workflow-triggering tag
## Test