### PR TITLE
feat: Support date type

### DIFF
--- a/source/ftrack_api/session.py
+++ b/source/ftrack_api/session.py
@@ -1797,6 +1797,8 @@ class Session(object):
             if "__type__" in item:
                 if item["__type__"] == "datetime":
                     item = arrow.get(item["value"])
+                elif item["__type__"] == "date":
+                    item = arrow.get(item["value"])
 
             elif "__entity_type__" in item:
                 item = self._create(item["__entity_type__"], item, reconstructing=True)


### PR DESCRIPTION
Properly convert date type to arrow object.

Resolves f-677

- [x] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] ~~The PR contains updates to the release notes.~~
- [x] I have verified that the documentation is still up to date.

## Changes
When querying for a field of type `date`, we'll properly convert that to an arrow object, whereas prior it has been returned as a dict.

As arrow objects ALWAYS include the time, this will result in a date with a time set to midnight (00:00:00).

We don't actually expect an input like `{"__type__": "date", "value": "2023-10-10T09:50:34"}` (with time).

For local testing or testing against a PR server:
https://github.com/ftrackhq/ftrack-server/pull/1591

## Test
Run unit test `test/unit/test_session.py:test_decode_date_and_datetime`.

Use this code to test manually:
```
from ftrack_api import Session
import json

session = Session()

dates = [
    {"__type__": "date", "value": "2023-10-10"},
    {"__type__": "date", "value": "2023-10-10T09:50:34"},
    {"__type__": "date", "value": "2023-10-10T00:00:00"},
    {"__type__": "date", "value": "2023-10-10T24:00:00"},
    {"__type__": "date", "value": "2023-10-10T23:00:00+02:00"},
    {"__type__": "date", "value": "2023-10-10T23:00:00-02:00"},
    {"__type__": "datetime", "value": "2023-10-10"},
    {"__type__": "datetime", "value": "2023-10-10T09:50:34"},
    {"__type__": "datetime", "value": "2023-10-10T00:00:00"},
    {"__type__": "datetime", "value": "2023-10-10T24:00:00"},
    {"__type__": "datetime", "value": "2023-10-10T23:00:00+02:00"},
    {"__type__": "datetime", "value": "2023-10-10T23:00:00-02:00"}
]

for date in dates:
    foobar = session.decode(
        json.dumps(
            [{"action":"query","data":[
                {
                    "__entity_type__":"Task","id":"0004902a-a7bc-4363-8e3b-bd18c0bed594",
                    "created_at": date,
                    "context_type":"task",
                    "object_type_id":"11c137c0-ee7e-4f9c-91c5-8c77cec22b2c",
                    "project_id":"5d253dc2-ff1a-49ef-9646-d7fc1196e860"
                }
            ],"metadata":{"next":{"offset":1}}}])
    )

    print("----------------------------")
    print(date)
    print(type(foobar[0]["data"][0]["created_at"]), foobar[0]["data"][0]["created_at"])

```
