### PR TITLE
fix: add missing timeouts to server accessor

### DIFF
--- a/source/ftrack_api/accessor/server.py
+++ b/source/ftrack_api/accessor/server.py
@@ -4,7 +4,6 @@
 import os
 import hashlib
 import base64
-import json
 
 import requests
 
@@ -22,6 +21,7 @@ class ServerFile(String):
         self.mode = mode
         self.resource_identifier = resource_identifier
         self._session = session
+        self._timeout = session.request_timeout
         self._has_read = False
 
         super(ServerFile, self).__init__()
@@ -54,6 +54,7 @@ class ServerFile(String):
                 "apiKey": self._session.api_key,
             },
             stream=True,
+            timeout=self._timeout,
         )
 
         try:
@@ -105,7 +106,10 @@ class ServerFile(String):
 
         # Put the file based on the metadata.
         response = requests.put(
-            metadata["url"], data=self.wrapped_file, headers=metadata["headers"]
+            metadata["url"],
+            data=self.wrapped_file,
+            headers=metadata["headers"],
+            timeout=self._timeout,
         )
 
         try:
@@ -153,6 +157,7 @@ class _ServerAccessor(Accessor):
         super(_ServerAccessor, self).__init__(**kw)
 
         self._session = session
+        self._timeout = session.request_timeout
 
     def open(self, resource_identifier, mode="rb"):
         """Return :py:class:`~ftrack_api.Data` for *resource_identifier*."""
@@ -167,6 +172,7 @@ class _ServerAccessor(Accessor):
                 "username": self._session.api_user,
                 "apiKey": self._session.api_key,
             },
+            timeout=self._timeout,
         )
         if response.status_code != 200:
             raise ftrack_api.exception.AccessorOperationFailedError(


### PR DESCRIPTION
- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
Added request timeouts to the Server Accessor components, because there are no timeouts by default, and in some cases data operations might hang because of it.

I also had an idea to try and use `requests.sessions.Session` from `ftrack_api.session.Session` (`session_obj._request`) inside the Server Accessor. Then the accessor would use same connection pool and any customizations. But that requests session is configured with auth, and possibly some headers and cookies - not sure if it's desired or not in the accessor.