### PR TITLE
fix: F 769 server accessor timeout

### DIFF
--- a/source/ftrack_api/accessor/server.py
+++ b/source/ftrack_api/accessor/server.py
@@ -4,7 +4,6 @@
 import os
 import hashlib
 import base64
-import json
 
 import requests
 
@@ -22,6 +21,7 @@ class ServerFile(String):
         self.mode = mode
         self.resource_identifier = resource_identifier
         self._session = session
+        self._timeout = session.request_timeout
         self._has_read = False
 
         super(ServerFile, self).__init__()
@@ -54,6 +54,7 @@ class ServerFile(String):
                 "apiKey": self._session.api_key,
             },
             stream=True,
+            timeout=self._timeout,
         )
 
         try:
@@ -105,7 +106,10 @@ class ServerFile(String):
 
         # Put the file based on the metadata.
         response = requests.put(
-            metadata["url"], data=self.wrapped_file, headers=metadata["headers"]
+            metadata["url"],
+            data=self.wrapped_file,
+            headers=metadata["headers"],
+            timeout=self._timeout,
         )
 
         try:
@@ -153,6 +157,7 @@ class _ServerAccessor(Accessor):
         super(_ServerAccessor, self).__init__(**kw)
 
         self._session = session
+        self._timeout = session.request_timeout
 
     def open(self, resource_identifier, mode="rb"):
         """Return :py:class:`~ftrack_api.Data` for *resource_identifier*."""
@@ -167,6 +172,7 @@ class _ServerAccessor(Accessor):
                 "username": self._session.api_user,
                 "apiKey": self._session.api_key,
             },
+            timeout=self._timeout,
         )
         if response.status_code != 200:
             raise ftrack_api.exception.AccessorOperationFailedError(

--- a/test/unit/accessor/test_server.py
+++ b/test/unit/accessor/test_server.py
@@ -39,3 +39,60 @@ def test_remove_data(new_component, session):
     data = accessor.open(new_component["id"], "r")
     with pytest.raises(ftrack_api.exception.AccessorOperationFailedError):
         data.read()
+
+
+def test_read_timeout(new_component, session, monkeypatch):
+    """Test that read operations respect timeout settings."""
+    random_data = uuid.uuid1().hex.encode()
+
+    # First, write some data so there's something to read
+    accessor = ftrack_api.accessor.server._ServerAccessor(session)
+    http_file = accessor.open(new_component["id"], mode="wb")
+    http_file.write(random_data)
+    http_file.close()
+
+    # Set an impossibly short timeout - no server can respond this fast
+    monkeypatch.setattr(session, "request_timeout", 0.0001)
+
+    # Open a new file handle (this captures the patched timeout)
+    data = accessor.open(new_component["id"], "r")
+    with pytest.raises(
+        ftrack_api.exception.AccessorOperationFailedError, match="timed out"
+    ):
+        data.read()
+
+
+def test_write_timeout(new_component, session, monkeypatch):
+    """Test that write operations respect timeout settings."""
+    random_data = uuid.uuid1().hex.encode()
+
+    # Set an impossibly short timeout
+    monkeypatch.setattr(session, "request_timeout", 0.0001)
+
+    accessor = ftrack_api.accessor.server._ServerAccessor(session)
+    http_file = accessor.open(new_component["id"], mode="wb")
+    http_file.write(random_data)
+
+    # Timeout is caught and wrapped in AccessorOperationFailedError
+    with pytest.raises(
+        ftrack_api.exception.AccessorOperationFailedError, match="timed out"
+    ):
+        http_file.close()  # close() triggers flush() which triggers _write()
+
+
+def test_remove_timeout(new_component, session, monkeypatch):
+    """Test that remove operations respect timeout settings."""
+    # Write something first
+    accessor = ftrack_api.accessor.server._ServerAccessor(session)
+    http_file = accessor.open(new_component["id"], mode="wb")
+    http_file.write(b"test data")
+    http_file.close()
+
+    # Set timeout and create new accessor to pick up the timeout for remove()
+    monkeypatch.setattr(session, "request_timeout", 0.0001)
+    accessor = ftrack_api.accessor.server._ServerAccessor(session)
+
+    with pytest.raises(
+        ftrack_api.exception.AccessorOperationFailedError, match="timed out"
+    ):
+        accessor.remove(new_component["id"])

--- a/test/unit/accessor/test_server.py
+++ b/test/unit/accessor/test_server.py
@@ -11,7 +11,7 @@ import ftrack_api.accessor.server
 import ftrack_api.data
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def random_binary_data():
     return uuid.uuid1().hex.encode()
 


### PR DESCRIPTION
Resolves f-769

## Changes
Add request timeouts to the Server Accessor components, because there are no timeouts by default, and in some cases data operations might hang because of it.

Wrap all HTTP requests in the server accessor with consistent try/except
blocks that convert exceptions (including timeouts) to
AccessorOperationFailedError. This ensures callers get a uniform error
type regardless of the failure mode.

Changes to server.py:
- Wrap requests.get() in _read() with exception handling
- Wrap requests.get() in remove() with exception handling
- Replace manual status code check in remove() with raise_for_status()
  for consistency with _read() and _write()

Changes to test_server.py:
- Add separate tests for read, write, and remove timeout scenarios
- Use 0.0001s timeout to trigger real timeouts against the server
- All tests verify AccessorOperationFailedError is raised with timeout info
- 
## Test
Run unit tests.
