### PR TITLE
Fix SyntaxWarning on package init

### DIFF
--- a/source/ftrack_api/plugin.py
+++ b/source/ftrack_api/plugin.py
@@ -29,7 +29,7 @@ def load_source(modname, filename):
 
 
 def discover(paths, positional_arguments=None, keyword_arguments=None):
-    """Find and load plugins in search *paths*.
+    R"""Find and load plugins in search *paths*.
 
     Each discovered module should implement a register function that accepts
     *positional_arguments* and *keyword_arguments* as \*args and \*\*kwargs

--- a/source/ftrack_api/structure/standard.py
+++ b/source/ftrack_api/structure/standard.py
@@ -130,7 +130,7 @@ class StandardStructure(ftrack_api.structure.base.Structure):
 
         value = unicodedata.normalize("NFKD", str(value)).encode("ascii", "ignore")
         value = re.sub(
-            "[^\w\.-]", self.illegal_character_substitute, value.decode("utf-8")
+            r"[^\w\.-]", self.illegal_character_substitute, value.decode("utf-8")
         )
         return str(value.strip().lower())
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves https://github.com/ftrackhq/ftrack-python/issues/67

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
Fixed SyntaxWarning on package init. Described here: https://github.com/ftrackhq/ftrack-python/issues/67
Python 3.13 is already used in Houdini 22.0 and Maya 2027 so these warnings are annoying.

## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of internal text and filesystem sanitization patterns without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->